### PR TITLE
<h1> fixes as per Issue 138

### DIFF
--- a/index.html
+++ b/index.html
@@ -1832,7 +1832,7 @@
   </section>
 
   <section class="appendix" id="glossary">
-    <h1>Glossary</h1>
+    <h2>Glossary</h2>
     <table class="glossary">
     <thead>
       <tr>
@@ -2010,12 +2010,12 @@
   </section>
 
   <section class="appendix" id="html5-alignment">
-    <h1>Alignment with HTML5 Layout &amp; Formatting</h1>
+    <h2>Alignment with HTML5 Layout &amp; Formatting</h2>
     <p>This appendix is introduced to help ensure that the Ethiopic layout requirements in this recommendation has a sufficient and practical coverage in its scope.
        HTML5 is applied here for comparison as it is anticipated as the most frequently applied document language under which the recommendation will be applied.
        HTML5 elements will be reviewed in this appendix and remarks made to indicate that either: no recommendation is needed (western defaults are applicable),
        a document section is identified that covers the element in the Ethiopic context, or that a gap in coverage is identified and will be addressed.</p>
-    <h2>Layout</h2>
+    <h3>Layout</h3>
     <dl>
       <dt>&lt;header&gt;</dt>
       <dd><i>TBD Notes</i></dd>
@@ -2030,7 +2030,7 @@
       <dt>&lt;footer&gt;</dt>
       <dd><i>TBD Notes</i></dd>
     </dl>
-    <h2>Quotation &amp; Citation</h2>
+    <h3>Quotation &amp; Citation</h3>
     <dl>
       <dt>&lt;q&gt;</dt>
       <dd>Covered in <a href="#quotation"></a> (verify that &lt;q&gt; is sufficiently addressed).</dd>
@@ -2051,7 +2051,7 @@
       <dt>&lt;summary&gt;</dt>
       <dd><i>TBD Notes</i></dd>
     </dl>
-    <h2>Formatting</h2>
+    <h3>Formatting</h3>
     <dl>
       <dt>&lt;b&gt;</dt>
       <dd><i>TBD Notes</i></dd>
@@ -2075,7 +2075,7 @@
       <dt>&lt;sup&gt;</dt>
       <dd>Review: Assume for now that the vertical offset for Latin script is adequate.</dd>
     </dl>
-    <h2>Lists</h2>
+    <h3>Lists</h3>
     <dl>
       <dt>&lt;ul&gt;</dt>
       <dd>Covered in <a href="#bullet_lists"></a>.</dd>
@@ -2093,14 +2093,14 @@
   </section>
 
   <section class="appendix" id="acknowledgements">
-    <h1>Acknowledgements</h1>
+    <h2>Acknowledgements</h2>
     <p>Special thanks to the following people who contributed to this document (contributors’ names listed in in alphabetic order).</p>
     <p class="acknowledgement">This Person, That Person, etc</p>
     <p data-lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/elreq/graphs/contributors">GitHub contributors list</a>.</p>
   </section>
 
   <section class="appendix" id="references">
-    <h1>References</h1>
+    <h2>References</h2>
     <dl class="ref">
       <dt>Pankhurst, 1998</dt>
       <dd>


### PR DESCRIPTION
Hello @xfq, this update to the index.html file decrements the &lt;h1&gt; level headers to &lt;h2&gt; and similarly decrements any subheaders within.  The only remaining &lt;h1&gt;  appears in an example text -if this is inappropriate, I can apply CSS styling to simulate the example &lt;h1&gt; instead.